### PR TITLE
add __LP64__ define (to solve arch issue with iPhone X)

### DIFF
--- a/osc/OscOutboundPacketStream.h
+++ b/osc/OscOutboundPacketStream.h
@@ -105,7 +105,7 @@ public:
     OutboundPacketStream& operator<<( const InfinitumType& rhs );
     OutboundPacketStream& operator<<( int32 rhs );
 
-#if !(defined(__x86_64__) || defined(_M_X64))
+#if !(defined(__x86_64__) || defined(_M_X64) || defined(__LP64__))
     OutboundPacketStream& operator<<( int rhs )
             { *this << (int32)rhs; return *this; }
 #endif

--- a/osc/OscReceivedElements.h
+++ b/osc/OscReceivedElements.h
@@ -100,7 +100,7 @@ public:
         : contents_( contents )
         , size_( ValidateSize( (osc_bundle_element_size_t)size ) ) {}
 
-#if !(defined(__x86_64__) || defined(_M_X64))
+#if !(defined(__x86_64__) || defined(_M_X64) || defined(__LP64__))
     ReceivedPacket( const char *contents, int size )
         : contents_( contents )
         , size_( ValidateSize( (osc_bundle_element_size_t)size ) ) {}

--- a/osc/OscTypes.h
+++ b/osc/OscTypes.h
@@ -47,7 +47,7 @@ namespace osc{
 typedef __int64 int64;
 typedef unsigned __int64 uint64;
 
-#elif defined(__x86_64__) || defined(_M_X64)
+#elif defined(__x86_64__) || defined(_M_X64) || defined(__LP64__)
 
 typedef long int64;
 typedef unsigned long uint64;
@@ -61,7 +61,7 @@ typedef unsigned long long uint64;
 
 
 
-#if defined(__x86_64__) || defined(_M_X64)
+#if defined(__x86_64__) || defined(_M_X64) || defined(__LP64__)
 
 typedef signed int int32;
 typedef unsigned int uint32;


### PR DESCRIPTION
otherwise the system fails on assert( sizeof(osc::int32) == 4 ) on iPhone X