### PR TITLE
increase maximum buffer size to UDP/IPv4 practical limit

### DIFF
--- a/ip/posix/UdpSocket.cpp
+++ b/ip/posix/UdpSocket.cpp
@@ -440,7 +440,7 @@ public:
                 timerQueue_.push_back( std::make_pair( currentTimeMs + i->initialDelayMs, *i ) );
             std::sort( timerQueue_.begin(), timerQueue_.end(), CompareScheduledTimerCalls );
 
-            const int MAX_BUFFER_SIZE = 4098;
+            const int MAX_BUFFER_SIZE = 65507;
             data = new char[ MAX_BUFFER_SIZE ];
             IpEndpointName remoteEndpoint;
 

--- a/ip/win32/UdpSocket.cpp
+++ b/ip/win32/UdpSocket.cpp
@@ -429,7 +429,7 @@ public:
 			timerQueue_.push_back( std::make_pair( currentTimeMs + i->initialDelayMs, *i ) );
 		std::sort( timerQueue_.begin(), timerQueue_.end(), CompareScheduledTimerCalls );
 
-		const int MAX_BUFFER_SIZE = 4098;
+		const int MAX_BUFFER_SIZE = 65507;
 		char *data = new char[ MAX_BUFFER_SIZE ];
 		IpEndpointName remoteEndpoint;
 


### PR DESCRIPTION
> the actual limit for the data length, which is imposed by the underlying IPv4 protocol, is 65,507 bytes (65,535 − 8 byte UDP header − 20 byte IP header)

<https://en.wikipedia.org/wiki/User_Datagram_Protocol>
